### PR TITLE
Update Avada-da_DK.po

### DIFF
--- a/Avada/Avada-da_DK.po
+++ b/Avada/Avada-da_DK.po
@@ -13702,10 +13702,7 @@ msgstr ""
 # @ Avada
 #. Template Name of the plugin/theme
 msgid "Contact"
-msgstr ""
-"Beklager, men det lader til, at der ikke er nogen brugbare betalingsmetoder "
-"for din stat. Kontakt os, hvis du har brug for hjælp eller hvis du ønsker at "
-"høre om alternative ordninger."
+msgstr "Kontakt"
 
 #. Template Name of the plugin/theme
 msgid "Side Navigation"


### PR DESCRIPTION
This is visible when you select the page template of a page. Instead of 'kontakt', it had a long text that had nothing to do with the word 'kontakt'