### PR TITLE
Atualização Avada-pt_BR.po

### DIFF
--- a/Avada/Avada-pt_BR.po
+++ b/Avada/Avada-pt_BR.po
@@ -1567,7 +1567,7 @@ msgstr "Entrar"
 
 #: includes/avada-functions.php:464
 msgid "Register"
-msgstr "Registrp"
+msgstr "Registro"
 
 #. translators: Number of items.
 #: includes/avada-functions.php:533


### PR DESCRIPTION
Desde já demonstro a minha gratidão por terem traduzido e disponibilizado a tradução do tema Avada para o pt-BR. Gostaria de fazer uma correção, na linha 1570 encontra-se:
                                                                  msgstr "Registrp"
A correção seria:
                                                                  msgstr "Registro"