### PR TITLE
Update fusion-builder-de_DE.po

### DIFF
--- a/fusion-builder/fusion-builder-de_DE.po
+++ b/fusion-builder/fusion-builder-de_DE.po
@@ -5,14 +5,14 @@ msgstr ""
 "Project-Id-Version: Fusion Builder 1.0\n"
 "Report-Msgid-Bugs-To: https://wordpress.org/support/plugin/fusion-builder\n"
 "POT-Creation-Date: 2019-05-01 11:41:30+00:00\n"
-"PO-Revision-Date: 2017-04-05 19:30+0200\n"
+"PO-Revision-Date: 2019-06-26 08:13+0200\n"
 "Last-Translator: Aristeides <aristath@aristeidiss-mbp>\n"
 "Language-Team: German\n"
 "Language: de\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"X-Generator: Poedit 2.0\n"
+"X-Generator: Poedit 2.2.3\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 #: fusion-builder.php:391
@@ -25,6 +25,10 @@ msgid ""
 "update with your changes when you click the update button. This is not a "
 "real page, only a saved container."
 msgstr ""
+"Sie bearbeiten einen gespeicherten Container in der Fusion Builder "
+"Bibliothek, der mit Ihren Änderungen aktualisiert wird, wenn Sie auf den "
+"Aktualisierung Button klicken. Dies ist keine echte Seite, nur ein "
+"gespeicherter Container."
 
 #: fusion-builder.php:634
 msgid ""
@@ -32,6 +36,9 @@ msgid ""
 "update with your changes when you click the update button. This is not a "
 "real page, only a saved column."
 msgstr ""
+"Sie bearbeiten eine gespeicherte Spalte in der Fusion Builder Bibliothek, "
+"die mit Ihren Änderungen aktualisiert wird, wenn Sie auf den Aktualisierung "
+"Button klicken. Dies ist keine echte Seite, nur eine gespeicherte Spalte."
 
 #: fusion-builder.php:636
 msgid ""
@@ -39,6 +46,9 @@ msgid ""
 "update with your changes when you click the update button. This is not a "
 "real page, only a saved element."
 msgstr ""
+"Sie bearbeiten ein gespeichertes Element in der Fusion Builder Bibliothek, "
+"das mit Ihren Änderungen aktualisiert wird, wenn Sie auf den Aktualisierung "
+"Button klicken. Dies ist keine echte Seite, nur ein gespeichertes Element."
 
 #: fusion-builder.php:657
 msgid "Fusion Builder Settings"
@@ -46,16 +56,16 @@ msgstr "Fusion Builder Einstellungen"
 
 #: fusion-builder.php:659
 msgid "Important"
-msgstr ""
+msgstr "Wichtig!"
 
 #: fusion-builder.php:1472 fusion-builder.php:1476
 msgid "Edit With Default Editor"
-msgstr ""
+msgstr "Mit dem Standard Editor bearbeiten"
 
 #: fusion-builder.php:1472 fusion-builder.php:1476
 #: inc/class-fusion-builder-gutenberg.php:108
 msgid "Edit With Fusion Builder"
-msgstr ""
+msgstr "Mit dem Fusion Builder bearbeiten"
 
 #. Plugin Name of the plugin/theme
 msgid "Fusion Builder"
@@ -84,7 +94,7 @@ msgstr ""
 
 #: inc/admin-screens/addons.php:7
 msgid "developer documentation"
-msgstr ""
+msgstr "Online-Dokumentation"
 
 #: inc/admin-screens/addons.php:8
 msgid ""
@@ -96,7 +106,7 @@ msgstr ""
 
 #: inc/admin-screens/addons.php:56
 msgid "Active:"
-msgstr ""
+msgstr "Aktiv:"
 
 #: inc/admin-screens/addons.php:65
 msgid "v%1$s | %2$s"
@@ -104,11 +114,11 @@ msgstr ""
 
 #: inc/admin-screens/addons.php:75
 msgid "Deactivate"
-msgstr ""
+msgstr "Deaktivieren"
 
 #: inc/admin-screens/addons.php:77
 msgid "Activate"
-msgstr ""
+msgstr "Aktivieren"
 
 #: inc/admin-screens/addons.php:80
 msgid "Get Add-on"
@@ -116,7 +126,7 @@ msgstr ""
 
 #: inc/admin-screens/addons.php:93
 msgid "New"
-msgstr ""
+msgstr "Neu"
 
 #: inc/admin-screens/faq.php:8
 msgid ""
@@ -194,7 +204,7 @@ msgstr ""
 
 #: inc/admin-screens/faq.php:56
 msgid "Installation of bundled/required plugins."
-msgstr ""
+msgstr "Installation/Update benötigter Plugins notwendig"
 
 #: inc/admin-screens/faq.php:57
 msgid "Installation of included demo content."
@@ -397,7 +407,7 @@ msgstr "Aus"
 #: inc/class-fusion-builder-options-panel.php:146
 #: inc/class-fusion-builder-options-panel.php:155 inc/options/elements.php:20
 msgid "Fusion Builder Elements"
-msgstr ""
+msgstr "Fusion Builder Elemente"
 
 #: inc/admin-screens/settings.php:69
 msgid ""
@@ -422,11 +432,11 @@ msgstr ""
 
 #: inc/admin-screens/settings.php:73
 msgid "Check All Elements"
-msgstr ""
+msgstr "Alle Elemente auswählen"
 
 #: inc/admin-screens/settings.php:75
 msgid "Uncheck All Elements"
-msgstr ""
+msgstr "Alle Elemente abwählen"
 
 #: inc/admin-screens/settings.php:86
 msgid "Woo Featured"
@@ -713,21 +723,21 @@ msgstr ""
 #: shortcodes/fusion-sharingbox.php:748 shortcodes/fusion-title.php:470
 #: shortcodes/fusion-title.php:479 shortcodes/fusion-toggle.php:872
 msgid "Title"
-msgstr ""
+msgstr "Titel"
 
 #: inc/class-fusion-builder-library-table.php:102
 #: shortcodes/fusion-pricing-table.php:600 shortcodes/fusion-table.php:153
 msgid "Type"
-msgstr ""
+msgstr "Typ"
 
 #: inc/class-fusion-builder-library-table.php:103
 msgid "Global"
-msgstr ""
+msgstr "Global"
 
 #: inc/class-fusion-builder-library-table.php:104
 #: shortcodes/fusion-blog.php:2315
 msgid "Date"
-msgstr ""
+msgstr "Datum"
 
 #: inc/class-fusion-builder-library-table.php:208 inc/helpers.php:796
 #: shortcodes/fusion-container.php:753
@@ -737,16 +747,16 @@ msgstr ""
 #: inc/class-fusion-builder-library-table.php:210 inc/helpers.php:808
 #: inc/helpers.php:908 shortcodes/fusion-column.php:882
 msgid "Column"
-msgstr ""
+msgstr "Spalte"
 
 #: inc/class-fusion-builder-library-table.php:217
 msgid "Template"
-msgstr ""
+msgstr "Vorlage"
 
 #: inc/class-fusion-builder-library-table.php:275
 #: inc/class-fusion-builder-library-table.php:320
 msgid "Restore"
-msgstr ""
+msgstr "Wiederherstellen"
 
 #: inc/class-fusion-builder-library-table.php:276
 #: inc/class-fusion-builder-library-table.php:321
@@ -757,30 +767,30 @@ msgstr ""
 #: inc/layouts.php:419 inc/layouts.php:503 inc/layouts.php:572
 #: inc/layouts.php:858 inc/layouts.php:876 inc/templates/context-menu.php:99
 msgid "Edit"
-msgstr ""
+msgstr "Bearbeiten"
 
 #: inc/class-fusion-builder-library-table.php:279
 msgid "Trash"
-msgstr ""
+msgstr "Papierkorb"
 
 #: inc/class-fusion-builder-library-table.php:301
 #: inc/class-fusion-builder-library-table.php:430
 #: shortcodes/fusion-container.php:867
 msgid "Published"
-msgstr ""
+msgstr "Veröffentlicht"
 
 #: inc/class-fusion-builder-library-table.php:303
 #: shortcodes/fusion-blog.php:2320
 msgid "Last Modified"
-msgstr ""
+msgstr "Zuletzt bearbeitet"
 
 #: inc/class-fusion-builder-library-table.php:325
 msgid "Move to Trash"
-msgstr ""
+msgstr "In Papierkorb verschieben"
 
 #: inc/class-fusion-builder-library-table.php:352
 msgid "Fusion library is empty."
-msgstr ""
+msgstr "Die Fusion Bibliothek ist leer."
 
 #: inc/class-fusion-builder-library-table.php:432 inc/layouts.php:207
 msgid "Containers"
@@ -791,7 +801,7 @@ msgstr ""
 #: inc/lib/inc/class-fusion-settings.php:494
 #: inc/lib/inc/class-fusion-settings.php:503
 msgid "Element Options"
-msgstr ""
+msgstr "Element Optionen"
 
 #: inc/class-fusion-builder-options-panel.php:171
 msgid ""
@@ -803,24 +813,24 @@ msgstr ""
 
 #: inc/fusion-builder-admin.php:33
 msgid "Update"
-msgstr ""
+msgstr "Aktualisieren"
 
 #: inc/fusion-builder-admin.php:33
 msgid "Publish"
-msgstr ""
+msgstr "Veröffentlichen"
 
 #: inc/fusion-builder-admin.php:47
 msgid "Preview"
-msgstr ""
+msgstr "Vorschau"
 
 #: inc/fusion-builder-admin.php:49
 msgid "Save Draft"
-msgstr ""
+msgstr "Vorlage speichern"
 
 #: inc/fusion-builder-admin.php:66 inc/fusion-builder-admin.php:259
 #: inc/helpers.php:787 inc/layouts.php:201
 msgid "Library"
-msgstr ""
+msgstr "Bibliothek"
 
 #: inc/fusion-builder-admin.php:67 inc/fusion-builder-admin.php:260
 msgid "Add-ons"
@@ -1053,7 +1063,7 @@ msgstr "Standard"
 
 #: inc/helpers.php:305
 msgid "empty blank"
-msgstr ""
+msgstr "Leere Seite"
 
 #: inc/helpers.php:309 inc/helpers.php:475 inc/helpers.php:591
 msgid "full one 1"
@@ -1179,51 +1189,51 @@ msgstr ""
 
 #: inc/helpers.php:790
 msgid "Undo"
-msgstr ""
+msgstr "Zurück"
 
 #: inc/helpers.php:791
 msgid "Redo"
-msgstr ""
+msgstr "Wiederholen"
 
 #: inc/helpers.php:792 inc/templates/context-menu.php:105
 msgid "Save"
-msgstr ""
+msgstr "Speichern"
 
 #: inc/helpers.php:793
 msgid "Delete item"
-msgstr ""
+msgstr "Element löschen"
 
 #: inc/helpers.php:794
 msgid "Clone item"
-msgstr ""
+msgstr "Element klonen"
 
 #: inc/helpers.php:795
 msgid "Edit item"
-msgstr ""
+msgstr "Element bearbeiten"
 
 #: inc/helpers.php:797
 msgid "Container Settings"
-msgstr ""
+msgstr "Container Einstellungen"
 
 #: inc/helpers.php:798
 msgid "Insert Container"
-msgstr ""
+msgstr "Container Einfügen"
 
 #: inc/helpers.php:799
 msgid "Clone Container"
-msgstr ""
+msgstr "Container klonen"
 
 #: inc/helpers.php:800
 msgid "Save Container"
-msgstr ""
+msgstr "Container Speichern"
 
 #: inc/helpers.php:801
 msgid "Delete Container"
-msgstr ""
+msgstr "Container Löschen"
 
 #: inc/helpers.php:802
 msgid "Builder Containers"
-msgstr ""
+msgstr "Builder Container"
 
 #: inc/helpers.php:803
 msgid "Click to toggle"
@@ -1231,63 +1241,67 @@ msgstr ""
 
 #: inc/helpers.php:804
 msgid "Save Custom Container"
-msgstr ""
+msgstr "Benutzerdefinierten Container speichern"
 
 #: inc/helpers.php:805
 msgid "Save Custom Template"
-msgstr ""
+msgstr "Benutzerdefinierte Vorlage speichern"
 
 #: inc/helpers.php:806
 msgid "Custom containers will be stored and managed on the Library tab"
 msgstr ""
+"Benutzerdefinierte Container werden im Bibliotheks-Tab gespeichert und "
+"verwaltet"
 
 #: inc/helpers.php:807
 msgid "Enter Name..."
-msgstr ""
+msgstr "Name eingeben..."
 
 #: inc/helpers.php:809 inc/layouts.php:208
 msgid "Columns"
-msgstr ""
+msgstr "Spalten"
 
 #: inc/helpers.php:810
 msgid "Resize column"
-msgstr ""
+msgstr "Größe der Spalte ändern"
 
 #: inc/helpers.php:811
 msgid "Resized Column to"
-msgstr ""
+msgstr "Größe der Spalte geändert zu"
 
 #: inc/helpers.php:812
 msgid "Column settings"
-msgstr ""
+msgstr "Spalten-Einstellungen"
 
 #: inc/helpers.php:813 inc/helpers.php:817
 msgid "Clone column"
-msgstr ""
+msgstr "Spalte klonen"
 
 #: inc/helpers.php:814
 msgid "Save column"
-msgstr ""
+msgstr "Spalte speichern"
 
 #: inc/helpers.php:815
 msgid "Delete column"
-msgstr ""
+msgstr "Spalte löschen"
 
 #: inc/helpers.php:816
 msgid "Delete row"
-msgstr ""
+msgstr "Reihe löschen"
 
 #: inc/helpers.php:818
 msgid "Save Custom Column"
-msgstr ""
+msgstr "Benutzerdefinierte Spalte speichern"
 
 #: inc/helpers.php:819 inc/helpers.php:839
 msgid "Custom elements will be stored and managed on the Library tab"
 msgstr ""
+"Benutzerdefinierte Elemente werden im Bibliotheks-Tab gespeichert und "
+"verwaltet"
 
 #: inc/helpers.php:820
 msgid "Add element"
-msgstr ""
+msgstr "Element hinzufügen"
 
 #: inc/helpers.php:822
 msgid "Insert Columns"
@@ -1459,25 +1473,28 @@ msgstr "Einfügen"
 
 #: inc/helpers.php:864
 msgid "Pre-Built Page"
-msgstr ""
+msgstr "Vorgefertigte Seite"
 
 #: inc/helpers.php:865
 msgid "To get started, add a Container, or add a pre-built page."
 msgstr ""
+"Um zu beginnen, einen Container oder eine vorgefertigte Seite hinzufügen."
 
 #: inc/helpers.php:866
 msgid ""
 "The building process always starts with a container, then columns, then "
 "elements."
 msgstr ""
+"Der Seitenaufbau beginnt immer mit einem Container, dann Spalten und dann "
+"Elemente."
 
 #: inc/helpers.php:867
 msgid "Watch The Video!"
-msgstr ""
+msgstr "Video ansehen"
 
 #: inc/helpers.php:868
 msgid "Edit Settings"
-msgstr ""
+msgstr "Einstellungen bearbeiten"
 
 #: inc/helpers.php:869
 msgid "Backward History"
@@ -1485,7 +1502,7 @@ msgstr ""
 
 #: inc/helpers.php:870
 msgid "Duplicate Content"
-msgstr ""
+msgstr "Inhalt duplizieren"
 
 #: inc/helpers.php:871
 msgid "Forward History"
@@ -1497,11 +1514,11 @@ msgstr ""
 
 #: inc/helpers.php:873
 msgid "Delete Content"
-msgstr ""
+msgstr "Inhalt entfernen"
 
 #: inc/helpers.php:874
 msgid "Add Content"
-msgstr ""
+msgstr "Inhalte hinzufügen"
 
 #: inc/helpers.php:875
 msgid "Click the ? icon to view additional documentation"
@@ -2147,7 +2164,7 @@ msgstr ""
 
 #: inc/layouts.php:19
 msgid "New Layout"
-msgstr ""
+msgstr "Neues Layout"
 
 #: inc/layouts.php:20
 msgid "All Layouts"
@@ -2171,7 +2188,7 @@ msgstr ""
 
 #: inc/layouts.php:25
 msgid "Layout published."
-msgstr ""
+msgstr "Layout veröffentlicht."
 
 #: inc/layouts.php:26
 msgid "Layout published privately."
@@ -2195,7 +2212,7 @@ msgstr ""
 
 #: inc/layouts.php:57
 msgid "Edit Element"
-msgstr ""
+msgstr "Element bearbeiten"
 
 #: inc/layouts.php:58
 msgid "New Element"
@@ -2203,15 +2220,15 @@ msgstr ""
 
 #: inc/layouts.php:59
 msgid "All Elements"
-msgstr ""
+msgstr "Alle Elemente"
 
 #: inc/layouts.php:60
 msgid "View Element"
-msgstr ""
+msgstr "Element ansehen"
 
 #: inc/layouts.php:61
 msgid "Search Elements"
-msgstr ""
+msgstr "Elemente durchsuchen"
 
 #: inc/layouts.php:64
 msgid "Element published."
@@ -2323,7 +2340,7 @@ msgstr ""
 
 #: inc/layouts.php:450
 msgid "Saved Elements"
-msgstr ""
+msgstr "Gespeicherte Elemente"
 
 #. translators: The "Fusion Documentation" link.
 #: inc/layouts.php:457
@@ -2343,15 +2360,15 @@ msgstr ""
 
 #: inc/layouts.php:532
 msgid "Save Template"
-msgstr ""
+msgstr "Vorlage speichern"
 
 #: inc/layouts.php:533
 msgid "Custom template name"
-msgstr ""
+msgstr "Eigener Vorlagenname"
 
 #: inc/layouts.php:537
 msgid "Save current page layout as a template"
-msgstr ""
+msgstr "Aktuelles Seiten-Layout als Vorlage speichern"
 
 #: inc/layouts.php:538
 msgid ""


### PR DESCRIPTION
I was wondering that the German language file for the Fusion Builder is translated very incomplete. The "Number 1 selling WordPress theme" does not have a full German translation? Strange. This is the only place for language files of Avada within the internet, isn't it? Should'nt be like that, so I will pull updates for this file now and then in the next time.