### PR TITLE
Update Avada-fi.po

### DIFF
--- a/Avada/Avada-fi.po
+++ b/Avada/Avada-fi.po
@@ -5214,7 +5214,7 @@ msgstr ""
 #: includes/lib/inc/fusion-app/class-fusion-app.php:427
 #: includes/metaboxes/metaboxes.php:412 includes/metaboxes/tabs/tab_page.php:28
 msgid "Page"
-msgstr "Hupsista, sivua ei löytynyt!"
+msgstr ""
 
 #: includes/lib/inc/fusion-app/class-fusion-app.php:557
 msgid "Fusion Builder Live"
@@ -8630,7 +8630,7 @@ msgstr "Postauksia: %s"
 #: includes/metaboxes/metaboxes.php:414
 #: includes/metaboxes/tabs/tab_header.php:44 includes/options/header.php:42
 msgid "Header"
-msgstr "Otsakkeet"
+msgstr ""
 
 # @ Avada
 #: includes/metaboxes/metaboxes.php:415
@@ -8649,7 +8649,7 @@ msgstr ""
 #: includes/metaboxes/tabs/tab_background.php:62
 #: includes/options/background.php:34 includes/options/menu.php:141
 msgid "Background"
-msgstr "tausta"
+msgstr ""
 
 # @ Avada
 #: includes/metaboxes/metaboxes.php:419


### PR DESCRIPTION
Fusion Page Options -kohdassa on käännetty väärin mm. Page -> Hupsista, sivua ei löydy (miksi tällainen käännös???), ja Background -> tausta (eikö se voisi olla vain Background) ja Header > Otsakkeet (eikö se voisi olla vain Header). Ottaisin ne pois, koska ovat ihan yleisesti käytössä olevia termejä. Olisi hyvä jos hallintasivujen tekstejä ei käännettäisi miten sattuu.