### PR TITLE
Update Avada-sv_SE.po

### DIFF
--- a/Avada/Avada-sv_SE.po
+++ b/Avada/Avada-sv_SE.po
@@ -196,7 +196,7 @@ msgstr "Du måste vara %sinloggad%s för att skriva en kommentar."
 #. tags.
 #: comments.php:93
 msgid "Logged in as %1$s. %2$sLog out &raquo;%3$s"
-msgstr "Inloggad som %1$s. %2$s Logga ut & raquo;%3$s"
+msgstr "Inloggad som %1$s. %2$s Logga ut &raquo;%3$s"
 
 # @ Avada
 #: comments.php:93


### PR DESCRIPTION
The space between '&' and 'raquo' makes that the icon will not be printed.