### PR TITLE
Update Greek translation

### DIFF
--- a/Avada/Avada-el.po
+++ b/Avada/Avada-el.po
@@ -2767,7 +2767,7 @@ msgstr ""
 # @ Avada
 #: includes/class-avada-megamenu-framework.php:118
 msgid "Default Style"
-msgstr "Προεπιλογή Παραγγελία"
+msgstr "Προεπιλογή"
 
 #: includes/class-avada-megamenu-framework.php:119
 msgid "Button Small"


### PR DESCRIPTION
The correct translation for "Deafault Style" in Greek is "Προεπιλογή" and not "Προεπιλογή Παραγγελία" as it was.