### PR TITLE
Fix sprintf error for fusion-builder-cs_CZ.po

### DIFF
--- a/fusion-builder/fusion-builder-cs_CZ.po
+++ b/fusion-builder/fusion-builder-cs_CZ.po
@@ -12955,7 +12955,7 @@ msgid ""
 "%1$s value of %2$s will be used."
 msgstr ""
 "  Ponechte prázdné pro hodnotu nastavenou v nadřazených možnostech. Je-li "
-"tento údaj také prázdný, bude použita hodnota %1$ z %2$s."
+"tento údaj také prázdný, bude použita hodnota %1$s z %2$s."
 
 #. translators: The default value.
 #: inc/lib/inc/class-fusion-settings.php:618


### PR DESCRIPTION
The Czech translation for inc/lib/inc/class-fusion-settings.php:585 was missing a "s" after "%1$" causing it to generate errors on newer php version. This PR adds the missing "s".